### PR TITLE
JENKINS-22402 do not store authorities in the config.xml

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -201,8 +201,9 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 
 	/**
 	 * The authorities that are granted to the authenticated user.
+	 * It is not necessary, that the authorities will be stored in the config.xml, they blow up the config.xml
 	 */
-	public GrantedAuthority[] authorities;
+	public transient GrantedAuthority[] authorities  = new GrantedAuthority[0];
 
 	/**
 	 * The name of the header which the username has to be extracted from.


### PR DESCRIPTION
JENKINS-22402
The authorities of each user are not required in the config.xml of
Jenkins and just blowing up the file.
