### PR TITLE
Repair null pointer exception when forwardedUser is null.  

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -399,10 +399,11 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 							throws IOException, ServletException {
 				HttpServletRequest r = (HttpServletRequest) request;
 
-				String userFromHeader = r.getHeader(forwardedUser);
+				String userFromHeader = null;
 
 				Authentication auth = Hudson.ANONYMOUS;
-				if (userFromHeader != null) {
+				if (forwardedUser != null
+                                        && (userFromHeader = r.getHeader(forwardedUser)) != null) {
 					//LOGGER.log(Level.INFO, "USER LOGGED IN: {0}", userFromHeader);
 					if (getLDAPURL() != null) {
 


### PR DESCRIPTION
This occurred when upgrading from a previous version, http://i.imgur.com/WzfWeVX.jpg.
