### PR TITLE
Add more robust handling of Authorization header for API tokens.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -403,7 +403,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 
 			        String authorization = null;
 				String userFromApiToken = null;
-				if ((authorization = r.getHeader("Authorization")) != null) {
+				if ((authorization = r.getHeader("Authorization")) != null && authorization.toLowerCase().startsWith("basic ")) {
 					String uidpassword = Scrambler.descramble(authorization.substring(6));
 					int idx = uidpassword.indexOf(':');
 					if (idx >= 0) {
@@ -411,7 +411,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 					        String password = uidpassword.substring(idx+1);
 
 						// attempt to authenticate as API token
-						User u = User.get(username);
+						User u = User.get(username, false);
 						ApiTokenProperty t = u.getProperty(ApiTokenProperty.class);
 						if (t != null && t.matchesPassword(password)) {
 						        userFromApiToken = username;


### PR DESCRIPTION
Adding a check to confirm the Authorization header is Basic, and preventing the
creation of the User when performing the API token authentication.

Bumped into this in a relatively weird configuration. The Apache configuration we're using doesn't strip the Authorization headers. This caused the creation of user directories with non-printable names whenever the Negotiate header happened to include a ":" in the base64 decoded string. The users were created automatically, because User#get(String) has the byproduct of actually creating the user, unless you pass `false` as the second argument.