### PR TITLE
add retries to mitigate LDAP failures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPUserDetailsService.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPUserDetailsService.java
@@ -72,6 +72,8 @@ public class ProxyLDAPUserDetailsService implements UserDetailsService {
 
 			return ldapUser;
 		} catch (LdapDataAccessException e) {
+			// I'm thinking of adding retries here to mitigate transient LDAP
+			// issues.
 			LOGGER.log(Level.WARNING, "Failed to search LDAP for username="+username,e);
 			throw new UserMayOrMayNotExistException(e.getMessage(),e);
 		}


### PR DESCRIPTION
I'd like to add retries to mitigate LDAP failures. Our internal LDAP server isn't 100% reliable. When a LDAP failure happens, the "reverse proxy" plugin would log out the issue for 15 minutes. This is a bad user experience. Adding retries should mitigate this issue. 

Let me know if this proposal is acceptable. If so, I'll try to submit a real pull request. Thanks!