### PR TITLE
Add configuration option for groupNameAttribute to use fields other than CN as group lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Jenkins Reverse Proxy Authentication and Authorisation Plugin
+# Jenkins Reverse Proxy Authentication and Authorisation Plugin
 
 The Reverse proxy plugin providers developers the ability to have easy and simple authentication and authorisation using SSO techniques. The plugin authenticates the user in Jenkins via a HTTP header field.
 
-When it comes to authorisation, the plugin has been extended in order to offer two flavours to developers: HTTP header containing LDAP groups; or LDAP discovery. When one of the mentioned favlours is used, the developer can have Jenkins configured to use role based matrix authorisation, that will read the groups that were fed to the Reverse Proxy plugin.
+When it comes to authorisation, the offers two options to developers: HTTP header containing LDAP groups or LDAP discovery. When one of the mentioned options is used, the developer can have Jenkins configured to use role based matrix authorisation, that will read the groups that were configured in the Reverse Proxy plugin.
 
-The default values for the HTTP header fields are:
+## The default values for the HTTP header fields are:
 
 1. Header User Name: X-Forwarded-User
 2. Header Groups Name: X-Forwarded-Groups
@@ -17,3 +17,5 @@ If no LDAP information is given, the default used will be the HEADER fields. How
 If the username is not forwarded to Jenkins, the user will be authenticated as ANONYMOUS. When LDAP groups are sent via the HTTP header, there is no check if the username exists in the LDAP directory, so protect your proxy in order to avoid HTTP Header injection. Once an username is informed, the user will be authenticated. If no groups are returned from the LDAP search, the user will still be authenticated, but no other grants will be given.
 
 However, once the LDAP is properly configured instead of groups on the HTTP header, there is guarantee that only the groups of a given user will be returned. There is no possibility to get groups injected via the header.
+
+See the fields in [ReverseProxySecurityRealm.java](https://github.com/jenkinsci/reverse-proxy-auth-plugin/blob/master/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java) for details about the available options. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Jenkins Reverse Proxy Authentication and Authorisation Plugin
 
-The Reverse Proxy Plugin providers developers the ability to have easy and simple Authentication and Authorisation using SSO techniques. The plugin expects that the user to have Jenkins authenticated agains will be informed via a HHTP header field.
+The Reverse proxy plugin providers developers the ability to have easy and simple authentication and authorisation using SSO techniques. The plugin authenticates the user in Jenkins via a HTTP header field.
 
-When it comes to Authorisation, the plugin has been extended in order to offer two flavours to developers: HTTP header containing LDAP groups; or LDAP discovery. When one of the mentioned favlours is used, the developer can have Jenkins configured to use Role Based Matrix Authorisation, that will read the groups that were fed to the Reverse Proxy plugin.
+When it comes to authorisation, the plugin has been extended in order to offer two flavours to developers: HTTP header containing LDAP groups; or LDAP discovery. When one of the mentioned favlours is used, the developer can have Jenkins configured to use role based matrix authorisation, that will read the groups that were fed to the Reverse Proxy plugin.
 
 The default values for the HTTP header fields are:
 
@@ -14,7 +14,6 @@ The LDAP options can be displayed via the Advanced... button, located on the rig
 
 If no LDAP information is given, the default used will be the HEADER fields. However, if both are configured, the LDAP has priority over the HTTP header.
 
-If the username is not forwaded to Jenkins, the user will be authenticated as ANONYMOUS. When LDAP groups are sent via the HTTP header, there is no check if the username exists in the LDAP directory, so protect your proxy in order to avoid HTTP Header injection. Once an username is informed, the user will be authenticated. If no groups are returned from the LDAP search, the user will still be authenticated, but no other grants will be given.
+If the username is not forwarded to Jenkins, the user will be authenticated as ANONYMOUS. When LDAP groups are sent via the HTTP header, there is no check if the username exists in the LDAP directory, so protect your proxy in order to avoid HTTP Header injection. Once an username is informed, the user will be authenticated. If no groups are returned from the LDAP search, the user will still be authenticated, but no other grants will be given.
 
 However, once the LDAP is properly configured instead of groups on the HTTP header, there is guarantee that only the groups of a given user will be returned. There is no possibility to get groups injected via the header.
-

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -460,12 +460,10 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 				String userFromHeader = null;
 
 				Authentication auth = Hudson.ANONYMOUS;
-				if ((forwardedUser != null
-					 && (userFromHeader = r.getHeader(forwardedUser)) != null)
-					 || userFromApiToken != null) {
-					//LOGGER.log(Level.INFO, "USER LOGGED IN: {0}", userFromHeader);
-				        if (userFromHeader == null && userFromApiToken != null) {
-					        userFromHeader = userFromApiToken;
+				if ((forwardedUser != null && (userFromHeader = r.getHeader(forwardedUser)) != null) || userFromApiToken != null) {
+					LOGGER.log(Level.FINE, "USER LOGGED IN: {0}", userFromHeader);
+			        if (userFromHeader == null && userFromApiToken != null) {
+				        userFromHeader = userFromApiToken;
 					}
 
 					if (getLDAPURL() != null) {
@@ -606,7 +604,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
             LOGGER.log(Level.FINEST, "getAttributes is null");
         } else {
             hudson.model.User u = hudson.model.User.get(d.getUsername());
-            if (!StringUtils.isBlank(displayNameLdapAttribute)){
+            if (!StringUtils.isBlank(displayNameLdapAttribute)) {
                 LOGGER.log(Level.FINEST, "Getting user details from LDAP attributes");
                 try {
                     Attribute attribute = d.getAttributes().get(displayNameLdapAttribute);
@@ -690,16 +688,17 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 				@QueryParameter final String managerDN,
 				@QueryParameter final String managerPassword) {
 
-			if(!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
+			if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
 				return FormValidation.ok();
+			}
 
 			try {
 				Hashtable<String,String> props = new Hashtable<String,String>();
-				if(managerDN!=null && managerDN.trim().length() > 0  && !"undefined".equals(managerDN)) {
-					props.put(Context.SECURITY_PRINCIPAL,managerDN);
+				if (managerDN != null && managerDN.trim().length() > 0 && !"undefined".equals(managerDN)) {
+					props.put(Context.SECURITY_PRINCIPAL, managerDN);
 				}
-				if(managerPassword!=null && managerPassword.trim().length() > 0 && !"undefined".equals(managerPassword)) {
-					props.put(Context.SECURITY_CREDENTIALS,managerPassword);
+				if (managerPassword!=null && managerPassword.trim().length() > 0 && !"undefined".equals(managerPassword)) {
+					props.put(Context.SECURITY_CREDENTIALS, managerPassword);
 				}
 
 				props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
@@ -790,7 +789,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 					
 					authorityUpdateCache.put(userFromHeader, current);
 					
-					LOGGER.log(Level.INFO, "Authorities for user "+userFromHeader+" have been updated.");
+					LOGGER.log(Level.INFO, "Authorities for user " + userFromHeader + " have been updated.");
 				}
 			} else {
 				if (authorityUpdateCache == null) {

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthoritiesPopulatorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthoritiesPopulatorImpl.java
@@ -44,8 +44,7 @@ public final class ReverseProxyAuthoritiesPopulatorImpl extends DefaultReversePr
 	}
 
 	@Override
-	protected Set<GrantedAuthority> getAdditionalRoles(
-			ReverseProxyUserDetails proxyUser) {
+	protected Set<GrantedAuthority> getAdditionalRoles(ReverseProxyUserDetails proxyUser) {
 		return Collections.singleton(SecurityRealm.AUTHENTICATED_AUTHORITY);
 	}
 
@@ -71,8 +70,7 @@ public final class ReverseProxyAuthoritiesPopulatorImpl extends DefaultReversePr
 	@Override
 	public Set<GrantedAuthority> getGroupMembershipRoles(String username) {
 
-		Set<GrantedAuthority> names = super
-				.getGroupMembershipRoles(username);
+		Set<GrantedAuthority> names = super.getGroupMembershipRoles(username);
 
 		Set<GrantedAuthority> groupRoles = new HashSet<GrantedAuthority>(names.size() * 2);
 		groupRoles.addAll(names);

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPAuthoritiesPopulator.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPAuthoritiesPopulator.java
@@ -55,8 +55,8 @@ public class ProxyLDAPAuthoritiesPopulator extends DefaultLdapAuthoritiesPopulat
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
-	public Set getGroupMembershipRoles(String userDn, String username) {
-		Set<GrantedAuthority> names = super.getGroupMembershipRoles(userDn,username);
+	public Set<GrantedAuthority> getGroupMembershipRoles(String userDn, String username) {
+		Set<GrantedAuthority> names = super.getGroupMembershipRoles(userDn, username);
 
 		Set<GrantedAuthority> r = new HashSet<GrantedAuthority>(names.size()*2);
 		r.addAll(names);

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPUserDetailsService.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPUserDetailsService.java
@@ -59,7 +59,7 @@ public class ProxyLDAPUserDetailsService implements UserDetailsService {
 
 					// intern attributes
 					Attributes v = ldapUser.getAttributes();
-					if (v instanceof BasicAttributes) {// BasicAttributes.equals is what makes the interning possible
+					if (v instanceof BasicAttributes) { // BasicAttributes.equals is what makes the interning possible
 						synchronized (attributesCache) {
 							Attributes vv = (Attributes)attributesCache.get(v);
 							if (vv==null)   attributesCache.put(v,vv=v);

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -56,6 +56,9 @@ THE SOFTWARE.
     <f:entry title="${%Group membership filter}" >
       <f:textbox name="ldap.groupMembershipFilter" value="${instance.groupMembershipFilter}" />
     </f:entry>
+    <f:entry title="${%Group name attribute instead of CN}" >
+      <f:textbox name="ldap.groupNameAttribute" value="${instance.groupNameAttribute}" />
+    </f:entry>
     <f:entry title="${%Manager DN}" >
       <f:textbox name="managerDN" value="${instance.managerDN}" autocomplete="off"
          checkUrl="'${rootURL}/securityRealms/LDAPSecurityRealm/serverCheck?field=managerDN&amp;server='+encodeURIComponent(this.form.elements['ldap.server'].value)+'&amp;managerDN='+encodeURIComponent(this.value)+'&amp;managerPassword='+encodeURIComponent(this.form.elements['ldap.managerPassword'].value)"


### PR DESCRIPTION
The pull requests mainly consists of a new feature to be able to use other fields than CN for the group name. The group name is then displayed at the users page. This is useful when you want to search for a human readable group name instead of the technical name.

Besides that I added some documentation, cleaned up formating.