### PR TITLE
Enable custom log out redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Jenkins Reverse Proxy Authentication and Authorisation Plugin
+# Jenkins Reverse Proxy Authentication and Authorisation Plugin
 
-The Reverse Proxy Plugin providers developers the ability to have easy and simple Authentication and Authorisation using SSO techniques. The plugin expects that the user to have Jenkins authenticated agains will be informed via a HHTP header field.
+The Reverse proxy plugin providers developers the ability to have easy and simple authentication and authorisation using SSO techniques. The plugin authenticates the user in Jenkins via a HTTP header field.
 
-When it comes to Authorisation, the plugin has been extended in order to offer two flavours to developers: HTTP header containing LDAP groups; or LDAP discovery. When one of the mentioned favlours is used, the developer can have Jenkins configured to use Role Based Matrix Authorisation, that will read the groups that were fed to the Reverse Proxy plugin.
+When it comes to authorisation, the offers two options to developers: HTTP header containing LDAP groups or LDAP discovery. When one of the mentioned options is used, the developer can have Jenkins configured to use role based matrix authorisation, that will read the groups that were configured in the Reverse Proxy plugin.
 
-The default values for the HTTP header fields are:
+## The default values for the HTTP header fields are:
 
 1. Header User Name: X-Forwarded-User
 2. Header Groups Name: X-Forwarded-Groups
@@ -14,7 +14,8 @@ The LDAP options can be displayed via the Advanced... button, located on the rig
 
 If no LDAP information is given, the default used will be the HEADER fields. However, if both are configured, the LDAP has priority over the HTTP header.
 
-If the username is not forwaded to Jenkins, the user will be authenticated as ANONYMOUS. When LDAP groups are sent via the HTTP header, there is no check if the username exists in the LDAP directory, so protect your proxy in order to avoid HTTP Header injection. Once an username is informed, the user will be authenticated. If no groups are returned from the LDAP search, the user will still be authenticated, but no other grants will be given.
+If the username is not forwarded to Jenkins, the user will be authenticated as ANONYMOUS. When LDAP groups are sent via the HTTP header, there is no check if the username exists in the LDAP directory, so protect your proxy in order to avoid HTTP Header injection. Once an username is informed, the user will be authenticated. If no groups are returned from the LDAP search, the user will still be authenticated, but no other grants will be given.
 
 However, once the LDAP is properly configured instead of groups on the HTTP header, there is guarantee that only the groups of a given user will be returned. There is no possibility to get groups injected via the header.
 
+See the fields in [ReverseProxySecurityRealm.java](https://github.com/jenkinsci/reverse-proxy-auth-plugin/blob/master/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java) for details about the available options. 

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -102,6 +102,7 @@ import org.jenkinsci.plugins.reverse_proxy_auth.service.ProxyLDAPAuthoritiesPopu
 import org.jenkinsci.plugins.reverse_proxy_auth.service.ProxyLDAPUserDetailsService;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 import org.springframework.dao.DataAccessException;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -265,8 +266,13 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 
     private final String emailAddressLdapAttribute;
 
+	/**
+	 * Custom post logout url
+	 */
+	public final String customLogOutUrl;
+
 	@DataBoundConstructor
-	public ReverseProxySecurityRealm(String forwardedUser, String headerGroups, String headerGroupsDelimiter, String server, String rootDN, boolean inhibitInferRootDN,
+	public ReverseProxySecurityRealm(String forwardedUser, String headerGroups, String headerGroupsDelimiter, String customLogOutUrl, String server, String rootDN, boolean inhibitInferRootDN,
 			String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String groupNameAttribute, String managerDN, String managerPassword, 
 			Integer updateInterval, boolean disableLdapEmailResolver, String displayNameLdapAttribute, String emailAddressLdapAttribute) {
 
@@ -278,6 +284,13 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 		} else {
 			this.headerGroupsDelimiter = "|";
 		}
+
+		if(!StringUtils.isBlank(customLogOutUrl)) {
+			this.customLogOutUrl = customLogOutUrl;
+		} else {
+			this.customLogOutUrl = null;
+		}
+
 		this.server = fixEmptyAndTrim(server);
 		this.managerDN = fixEmpty(managerDN);
 		this.managerPassword = Scrambler.scramble(fixEmpty(managerPassword));
@@ -537,7 +550,20 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 
 	@Override
 	public boolean canLogOut() {
-		return false;
+		if (customLogOutUrl == null) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	@Override
+	public String getPostLogOutUrl(StaplerRequest req, Authentication auth) {
+		if (customLogOutUrl == null) {
+			return super.getPostLogOutUrl(req, auth);
+		} else {
+			return customLogOutUrl;
+		}
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthoritiesPopulatorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthoritiesPopulatorImpl.java
@@ -44,8 +44,7 @@ public final class ReverseProxyAuthoritiesPopulatorImpl extends DefaultReversePr
 	}
 
 	@Override
-	protected Set<GrantedAuthority> getAdditionalRoles(
-			ReverseProxyUserDetails proxyUser) {
+	protected Set<GrantedAuthority> getAdditionalRoles(ReverseProxyUserDetails proxyUser) {
 		return Collections.singleton(SecurityRealm.AUTHENTICATED_AUTHORITY);
 	}
 
@@ -71,8 +70,7 @@ public final class ReverseProxyAuthoritiesPopulatorImpl extends DefaultReversePr
 	@Override
 	public Set<GrantedAuthority> getGroupMembershipRoles(String username) {
 
-		Set<GrantedAuthority> names = super
-				.getGroupMembershipRoles(username);
+		Set<GrantedAuthority> names = super.getGroupMembershipRoles(username);
 
 		Set<GrantedAuthority> groupRoles = new HashSet<GrantedAuthority>(names.size() * 2);
 		groupRoles.addAll(names);

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPAuthoritiesPopulator.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPAuthoritiesPopulator.java
@@ -55,8 +55,8 @@ public class ProxyLDAPAuthoritiesPopulator extends DefaultLdapAuthoritiesPopulat
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
-	public Set getGroupMembershipRoles(String userDn, String username) {
-		Set<GrantedAuthority> names = super.getGroupMembershipRoles(userDn,username);
+	public Set<GrantedAuthority> getGroupMembershipRoles(String userDn, String username) {
+		Set<GrantedAuthority> names = super.getGroupMembershipRoles(userDn, username);
 
 		Set<GrantedAuthority> r = new HashSet<GrantedAuthority>(names.size()*2);
 		r.addAll(names);

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPUserDetailsService.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/service/ProxyLDAPUserDetailsService.java
@@ -59,7 +59,7 @@ public class ProxyLDAPUserDetailsService implements UserDetailsService {
 
 					// intern attributes
 					Attributes v = ldapUser.getAttributes();
-					if (v instanceof BasicAttributes) {// BasicAttributes.equals is what makes the interning possible
+					if (v instanceof BasicAttributes) { // BasicAttributes.equals is what makes the interning possible
 						synchronized (attributesCache) {
 							Attributes vv = (Attributes)attributesCache.get(v);
 							if (vv==null)   attributesCache.put(v,vv=v);

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -56,6 +56,9 @@ THE SOFTWARE.
     <f:entry title="${%Group membership filter}" >
       <f:textbox name="ldap.groupMembershipFilter" value="${instance.groupMembershipFilter}" />
     </f:entry>
+    <f:entry title="${%Group name attribute instead of CN}" >
+      <f:textbox name="ldap.groupNameAttribute" value="${instance.groupNameAttribute}" />
+    </f:entry>
     <f:entry title="${%Manager DN}" >
       <f:textbox name="managerDN" value="${instance.managerDN}" autocomplete="off"
          checkUrl="'${rootURL}/securityRealms/LDAPSecurityRealm/serverCheck?field=managerDN&amp;server='+encodeURIComponent(this.form.elements['ldap.server'].value)+'&amp;managerDN='+encodeURIComponent(this.value)+'&amp;managerPassword='+encodeURIComponent(this.form.elements['ldap.managerPassword'].value)"

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -33,6 +33,9 @@ THE SOFTWARE.
     <f:textbox field="headerGroupsDelimiter" default="|" />
   </f:entry>
   <f:advanced>  
+    <f:entry title="${%Custom Log Out URL}" >
+      <f:textbox name="customLogOutUrl" value="${instance.customLogOutUrl}" />
+    </f:entry>
 	<f:entry title="${%Server}" >
 	  <f:textbox name="server" value="${instance.server}"
             checkUrl="'${rootURL}/securityRealms/LDAPSecurityRealm/serverCheck?field=server&amp;server='+encodeURIComponent(this.value)+'&amp;managerDN='+encodeURIComponent(this.form.elements['managerDN'].value)+'&amp;managerPassword='+encodeURIComponent(this.form.elements['managerPassword'].value)"/>


### PR DESCRIPTION
Reverse proxies often include ways to log out of the portal that you are
logged in to. Some organizations have security requirements that require
the ability to log out from any application. This feature adds the ability
to log out and redirect to another page, presumably to log out of a
portal.