### PR TITLE
Add possibility for custom login link

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -269,10 +269,11 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 	/**
 	 * Custom post logout url
 	 */
+	public final String customLogInUrl;
 	public final String customLogOutUrl;
 
 	@DataBoundConstructor
-	public ReverseProxySecurityRealm(String forwardedUser, String headerGroups, String headerGroupsDelimiter, String customLogOutUrl, String server, String rootDN, boolean inhibitInferRootDN,
+	public ReverseProxySecurityRealm(String forwardedUser, String headerGroups, String headerGroupsDelimiter, String customLogInUrl, String customLogOutUrl, String server, String rootDN, boolean inhibitInferRootDN,
 			String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String groupNameAttribute, String managerDN, String managerPassword, 
 			Integer updateInterval, boolean disableLdapEmailResolver, String displayNameLdapAttribute, String emailAddressLdapAttribute) {
 
@@ -283,6 +284,12 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 			this.headerGroupsDelimiter = headerGroupsDelimiter.trim();
 		} else {
 			this.headerGroupsDelimiter = "|";
+		}
+
+		if(!StringUtils.isBlank(customLogInUrl)) {
+			this.customLogInUrl = customLogInUrl;
+		} else {
+			this.customLogInUrl = null;
 		}
 
 		if(!StringUtils.isBlank(customLogOutUrl)) {

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -33,6 +33,9 @@ THE SOFTWARE.
     <f:textbox field="headerGroupsDelimiter" default="|" />
   </f:entry>
   <f:advanced>  
+    <f:entry title="${%Custom Log In URL}" >
+      <f:textbox name="customLogInUrl" value="${instance.customLogInUrl}" />
+    </f:entry>
     <f:entry title="${%Custom Log Out URL}" >
       <f:textbox name="customLogOutUrl" value="${instance.customLogOutUrl}" />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/loginLink.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/loginLink.jelly
@@ -1,2 +1,5 @@
-<!-- no login link -->
-<j:jelly xmlns:j="jelly:core" />
+<j:jelly xmlns:j="jelly:core">
+  <j:if test="${it.customLogInUrl != null}">
+    <a href="${it.customLogInUrl}"><b>${%login}</b></a>
+  </j:if>
+</j:jelly>


### PR DESCRIPTION
This adds an option to set a custom login link, which is displayed when no user is logged in.
This can be used for setups where anonymous access to jenkins is possible and a session can be initiated through central authentication, e.g. Shibboleh.