### PR TITLE
Add email and display name header injection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Jenkins Reverse Proxy Authentication and Authorisation Plugin
+# Jenkins Reverse Proxy Authentication and Authorisation Plugin
 
 The Reverse Proxy Plugin providers developers the ability to have easy and simple Authentication and Authorisation using SSO techniques. The plugin expects that the user to have Jenkins authenticated agains will be informed via a HHTP header field.
 
@@ -21,7 +21,7 @@ If the username is not forwaded to Jenkins, the user will be authenticated as AN
 However, once the LDAP is properly configured instead of groups on the HTTP header, there is guarantee that only the groups of a given user will be returned. There is no possibility to get groups injected via the header.
 
 
-#Apache httpd configuration example
+## Apache httpd configuration example
 
 Here is a simple httpd configuration (apache.conf) made to proxypass 1 to 100 jenkins called ci00 to ci99.
 Basic authentication uses an AuthUserFile and many AuthLDAP.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ When it comes to Authorisation, the plugin has been extended in order to offer t
 The default values for the HTTP header fields are:
 
 1. Header User Name: X-Forwarded-User
-2. Header Groups Name: X-Forwarded-Groups
-3. Header Groups Delimiter: |
+2. Header User Mail: X-Forwarded-Mail
+3. Header User Display Name: X-Forwarded-DisplayName
+4. Header Groups Name: X-Forwarded-Groups
+5. Header Groups Delimiter: |
  
 The LDAP options can be displayed via the Advanced... button, located on the right side of the security settings.
 
@@ -18,3 +20,83 @@ If the username is not forwaded to Jenkins, the user will be authenticated as AN
 
 However, once the LDAP is properly configured instead of groups on the HTTP header, there is guarantee that only the groups of a given user will be returned. There is no possibility to get groups injected via the header.
 
+
+#Apache httpd configuration example
+
+Here is a simple httpd configuration (apache.conf) made to proxypass 1 to 100 jenkins called ci00 to ci99.
+Basic authentication uses an AuthUserFile and many AuthLDAP.
+User, display name, mail and groups are injected as headers.
+Injected groups are the ldap ones and the local httpd ones (in dbm format).
+
+```
+    <Location /ci01>
+        AuthBasicProvider auth-file ldap-1 ldap-2
+        AuthType Basic
+        AuthName "Jenkins"
+
+        Require valid-user
+        Order deny,allow
+        Allow from all
+    </Location>
+
+    <Location /ci02>
+        AuthBasicProvider auth-file ldap-1 ldap-2
+        AuthType Basic
+        AuthName "Jenkins"
+
+        Require valid-user
+        Order deny,allow
+        Allow from all
+    </Location>
+
+
+    #Redirect jenkins (for headers)
+    RewriteRule ^/ci01$ /ci01/ [R]
+    RewriteRule ^/ci02$ /ci02/ [R]
+
+    ProxyPass /ci01  http://jenkins-1-real-address/ci01 nocanon
+    ProxyPassReverse /ci01 http://jenkins-1-real-address/ci01
+
+    ProxyPass /ci02  http://jenkins-2-real-address/ci02 nocanon
+    ProxyPassReverse /ci02 http://jenkins-2-real-address/ci02
+
+    RewriteMap jenkins-groups dbm:/path-to-jenkins-groups.dbm
+
+    #WARNING jenkins is not protected on direct access !
+    #Allow any jenkins from ci00 to ci99
+
+
+     #Keep the location match regex as simple as possible
+     #Otherwise we may send some internal js call without authentication.
+     <LocationMatch  "^/ci\d\d">
+
+        # jenkins reverse proxy auth configuration
+        # prevent the client from setting this header
+        RequestHeader unset X-Forwarded-User
+        RequestHeader unset X-Forwarded-Groups
+        RequestHeader unset X-Forwarded-Mail
+        RequestHeader unset X-Forwarded-DisplayName
+
+        RequestHeader set X-Forwarded-Proto "https"
+        RequestHeader set X-Forwarded-Port "443"
+
+        # Adds the X-Forwarded-User header that indicates the current user name.
+        # this portion came from http://old.nabble.com/Forcing-a-proxied-host-to-generate-REMOTE_USER-td2911573.html#a2914465
+        RewriteEngine On
+        # see the Apache documentation on why this has to be lookahead
+        RewriteCond %{LA-U:REMOTE_USER} (.+)
+        # this actually doesn't rewrite anything. what we do here is to set RU to the match above
+        # "NS" prevents flooding the error log
+        RewriteRule .* - [E=RU:%1,NS]
+        RequestHeader set X-Forwarded-User %{RU}e
+
+        #inject mail & display name
+        RequestHeader set X-Forwarded-Mail %{AUTHENTICATE_MAIL}e
+        RequestHeader set X-Forwarded-DisplayName %{AUTHENTICATE_DISPLAYNAME}e
+
+        #inject groups
+        RewriteRule .* - [E=RG:${jenkins-groups:%{REMOTE_USER}}]
+        RequestHeader set X-Forwarded-Groups %{RG}e
+    </LocationMatch>
+
+```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>reverse-proxy-auth-plugin</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.5</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Reverse Proxy Auth Plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/ForwardedUserData.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/ForwardedUserData.java
@@ -1,0 +1,81 @@
+package org.jenkinsci.plugins.reverse_proxy_auth.data;
+
+import java.io.IOException;
+
+import hudson.model.User;
+import hudson.tasks.Mailer;
+
+/** 
+ * User data forwarded by the reverse proxy
+ * **/
+public class ForwardedUserData {
+        /** Empty header may be a null string **/
+        final private static String NULL_HEADER="(null)";
+        
+        private String email;
+        private String displayName;
+        public String getEmail() {
+                return email;
+        }
+        public void setEmail(String email) {
+                this.email = email;
+        }
+        public String getDisplayName() {
+                return displayName;
+        }
+        public void setDisplayName(String displayName) {
+                this.displayName = displayName;
+        }
+        
+        /** 
+         * Update the forwarded data to the jenkins user.
+         * @return true if updated and saved
+         * **/
+        public boolean update(User user) {
+                boolean toReturn=false;
+                if(updateDisplayName(user) || updateEmail(user)){
+                        toReturn=true;
+                        try {
+                                user.save();
+                        } catch (IOException e) {
+                                throw new IllegalStateException(e);
+                        }
+                }
+                
+                return toReturn;
+        }
+        
+        private boolean updateDisplayName(User user) {
+                boolean toReturn = false;
+                if(isNotNullHeader(displayName) && 
+                                !displayName.equals(user.getFullName())){
+                        user.setFullName(displayName);
+                        toReturn=true;
+                }
+                return toReturn;
+        }
+        
+        private boolean updateEmail(User user){
+                boolean toReturn = false;
+                if(isNotNullHeader(email)){
+                        Mailer.UserProperty emailProp = user.getProperty(
+                                        Mailer.UserProperty.class);
+                        if (emailProp == null || 
+                                        !email.equals(emailProp.getConfiguredAddress())) { 
+                                emailProp=new Mailer.UserProperty(email);
+                                try {
+                                        user.addProperty(emailProp);
+                                } catch (IOException e) {
+                                        throw new IllegalStateException(e);
+                                }
+                                toReturn=true;
+                        }
+                }
+                return toReturn;
+        }
+        
+        private static boolean isNotNullHeader(String value){
+                return value!=null && !value.equals(NULL_HEADER);
+        }
+        
+}

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -26,6 +26,12 @@ THE SOFTWARE.
   <f:entry title="${%Header User Name}">
     <f:textbox name="forwardedUser" value="${instance.forwardedUser}" default="X-Forwarded-User" />
   </f:entry>
+  <f:entry title="${%Header User Mail}">
+    <f:textbox name="forwardedEmail" value="${instance.forwardedEmail}" default="X-Forwarded-Mail" />
+  </f:entry>
+  <f:entry title="${%Header User Display Name}">
+    <f:textbox name="forwardedDisplayName" value="${instance.forwardedDisplayName}" default="X-Forwarded-DisplayName" />
+  </f:entry>
   <f:entry title="${%Header Groups Name}">
     <f:textbox field="headerGroups" default="X-Forwarded-Groups" />
   </f:entry>


### PR DESCRIPTION
Reverse-proxy-auth-plugin supports name & groups header injections but emails and display name are fetched from the LDAP server.

This fork add email and display name header injection support. 
Thus we can manage authentication and user profile data with an httpd server.

What's more, using an httpd server as a reverse proxy, provides a simple solution to:
- connect to several LDAP servers (even with different structures) 
- use technical users managed in the httpd server
- create an SSO plateform with other integrated applications

The original fork was made on tag 1.4.