### PR TITLE
[JENKINS-49236] - Prevent NullPointerException when null authContext is passed to the AuthoritiesPopulator

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySearchTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySearchTemplate.java
@@ -5,6 +5,8 @@ import java.util.Set;
 import org.acegisecurity.GrantedAuthority;
 import org.jenkinsci.plugins.reverse_proxy_auth.data.SearchTemplate;
 
+import javax.annotation.CheckForNull;
+
 /**
  * @author Wilder Rodrigues (wrodrigues@schubergphilis.com)
  */
@@ -14,7 +16,7 @@ public class ReverseProxySearchTemplate {
                 return ce.executeWithContext();
         }
 
-        public Set<String> searchForSingleAttributeValues(final SearchTemplate template, final GrantedAuthority [] authorities) {
+        public Set<String> searchForSingleAttributeValues(final SearchTemplate template, final @CheckForNull GrantedAuthority [] authorities) {
 
                 class SingleAttributeSearchCallback implements ContextExecutor {
 

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthoritiesPopulator.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthoritiesPopulator.java
@@ -114,7 +114,7 @@ public class DefaultReverseProxyAuthoritiesPopulator implements ReverseProxyAuth
 	public Set<GrantedAuthority> getGroupMembershipRoles(String username) {
 		Set<GrantedAuthority> authorities = new HashSet<GrantedAuthority>();
 
-		final @CheckForNull GrantedAuthority[] contextAuthorities = authContext.get(username);
+		final @CheckForNull GrantedAuthority[] contextAuthorities = authContext != null ? authContext.get(username) : null;
 
 		SearchTemplate searchTemplate = new UserSearchTemplate(username);
 

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthoritiesPopulator.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthoritiesPopulator.java
@@ -30,6 +30,8 @@ import org.jenkinsci.plugins.reverse_proxy_auth.data.UserSearchTemplate;
 import org.jenkinsci.plugins.reverse_proxy_auth.model.ReverseProxyUserDetails;
 import org.springframework.util.Assert;
 
+import javax.annotation.CheckForNull;
+
 
 /**
  * @author Wilder rodrigues (wrodrigues@schuberphilis.com)
@@ -56,14 +58,17 @@ public class DefaultReverseProxyAuthoritiesPopulator implements ReverseProxyAuth
 	private boolean convertToUpperCase = true;
 
 	//TODO: replace by a modern collection?
+	@CheckForNull
 	protected Hashtable<String, GrantedAuthority[]> authContext;
 
 	/**
 	 * Constructor for group search scenarios. <tt>userRoleAttributes</tt> may still be
 	 * set as a property.
+	 * @param authContext Authentication context.
+	 *                    May be {@code null}
 	 */
-	public DefaultReverseProxyAuthoritiesPopulator(Hashtable<String, GrantedAuthority[]> authContext) {
-		this.authContext = new Hashtable<>(authContext);
+	public DefaultReverseProxyAuthoritiesPopulator(@CheckForNull Hashtable<String, GrantedAuthority[]> authContext) {
+		this.authContext = authContext != null ? new Hashtable<>(authContext) : null;
 		reverseProxyTemplate = new ReverseProxySearchTemplate();
 	}
 
@@ -109,7 +114,7 @@ public class DefaultReverseProxyAuthoritiesPopulator implements ReverseProxyAuth
 	public Set<GrantedAuthority> getGroupMembershipRoles(String username) {
 		Set<GrantedAuthority> authorities = new HashSet<GrantedAuthority>();
 
-		GrantedAuthority[] contextAuthorities = authContext.get(username);
+		final @CheckForNull GrantedAuthority[] contextAuthorities = authContext.get(username);
 
 		SearchTemplate searchTemplate = new UserSearchTemplate(username);
 

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthoritiesPopulatorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthoritiesPopulatorImpl.java
@@ -26,6 +26,8 @@ import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.jenkinsci.plugins.reverse_proxy_auth.model.ReverseProxyUserDetails;
 
+import javax.annotation.CheckForNull;
+
 
 /**
  * @author Wilder rodrigues (wrodrigues@schuberphilis.com)
@@ -36,7 +38,7 @@ public final class ReverseProxyAuthoritiesPopulatorImpl extends DefaultReversePr
 	boolean convertToUpperCase = true;
 
 	public ReverseProxyAuthoritiesPopulatorImpl(
-			Hashtable<String, GrantedAuthority[]> authContext) {
+			@CheckForNull Hashtable<String, GrantedAuthority[]> authContext) {
 		super(authContext);
 
 		super.setRolePrefix("");

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/GroupSearchTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/GroupSearchTemplate.java
@@ -16,16 +16,15 @@ public class GroupSearchTemplate extends SearchTemplate {
         
         @Override
         public Set<String> processAuthorities(GrantedAuthority[] authorities) {
-                Set<String> authorityValues = this.doProcess(authorities);
-
-                return authorityValues;
+                return this.doProcess(authorities);
         }
         
         @Override
         protected Set<String> doProcess(GrantedAuthority[] authorities) {
+                //TODO: refactoring: use singleton
                 Set<String> authorityValues = new HashSet<String>();
                 authorityValues.add(userOrGroup);
-                
+
                 return authorityValues;
         }
 }

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/SearchTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/SearchTemplate.java
@@ -5,6 +5,9 @@ import java.util.Set;
 
 import org.acegisecurity.GrantedAuthority;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 /**
  * @author Wilder Rodrigues (wrodrigues@schubergphilis.com)
  */
@@ -17,8 +20,15 @@ public abstract class SearchTemplate {
         }
         
         public abstract Set<String> processAuthorities(final GrantedAuthority [] authorities);
-        
-        protected Set<String> doProcess(final GrantedAuthority [] authorities) {
+
+        /**
+         * Process authorities.
+         * @param authorities Authorities. Can be {@code null}.
+         * @return Set of group and user names
+         */
+        @Nonnull
+        protected Set<String> doProcess(final @CheckForNull GrantedAuthority [] authorities) {
+                // TODO: refactoring: use emptySet() ?
                 Set<String> authorityValues = new HashSet<String>();
                 if (authorities != null) {
                         for (int i = 0; i < authorities.length; i++) {

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/UserSearchTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/data/UserSearchTemplate.java
@@ -15,7 +15,6 @@ public class UserSearchTemplate extends SearchTemplate {
 
         @Override
         public Set<String> processAuthorities(GrantedAuthority[] authorities) {
-                Set<String> authorityValues = doProcess(authorities);
-                return authorityValues;
+                return doProcess(authorities);
         }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-49236

Reported as a regression in 1.6.0. #33 seems to be an obvious culprit, but it's actually not. Before #33 the plugin would just fail with NPE in `DefaultReverseProxyAuthoritiesPopulator#getGroupMembershipRoles()` assuming it's called from anywhere.