### PR TITLE
[JENKINS-49274] Run reverse-proxy filter after default filter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -563,7 +563,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 			}
 		};
 		Filter defaultFilter = super.createFilter(filterConfig);
-		return new ChainedServletFilter(filter, defaultFilter);
+		return new ChainedServletFilter(defaultFilter, filter);
 	}
 
 	@Override

--- a/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
@@ -1,0 +1,82 @@
+package org.jenkinsci.plugins.reverse_proxy_auth;
+
+import hudson.security.SecurityRealm;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.acegisecurity.userdetails.UserDetails;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.concurrent.Callable;
+
+public class ReverseProxySecurityRealmTest {
+    @Rule
+    public final JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private Jenkins jenkins;
+
+    @Before
+    public void setUp() {
+        jenkins = jenkinsRule.jenkins;
+    }
+
+    @Test
+    public void basicGetUserDetails() {
+        final ReverseProxySecurityRealm realm = createBasicRealm();
+        final UserDetails userDetails = realm.loadUserByUsername("test@example.com");
+        Assert.assertEquals("test@example.com", userDetails.getUsername());
+    }
+
+    @Test
+    @Issue("JENKINS-49274")
+    public void basicAuthenticate() throws Exception {
+        final ReverseProxySecurityRealm realm = createBasicRealm();
+        jenkins.setSecurityRealm(realm);
+
+        final JenkinsRule.WebClient client = jenkinsRule.createWebClient();
+        client.addRequestHeader(realm.getForwardedUser(), "test@example.com");
+        final Authentication authentication = client.executeOnServer(new Callable<Authentication>() {
+            @Override
+            public Authentication call() {
+                return Jenkins.getAuthentication();
+            }
+        });
+        Assert.assertEquals("Authentication should match",
+                new UsernamePasswordAuthenticationToken(
+                        "test@example.com",
+                        "",
+                        new GrantedAuthority[] { SecurityRealm.AUTHENTICATED_AUTHORITY }),
+                authentication);
+    }
+
+    private ReverseProxySecurityRealm createBasicRealm() {
+        return new ReverseProxySecurityRealm(
+                "X-Forwarded-User",   // forwardedUser
+                "X-Forwarded-Groups", // headerGroups
+                "|",                  // headerGroupsDelimiter
+                "",                   // customLogInUrl
+                "",                   // customLogOutUrl
+                "",                   // server
+                "",                   // rootDN
+                false,                // inhibitInferRootDN
+                "",                   // userSearchBase
+                "",                   // userSearch
+                "",                   // groupSearchBase
+                "",                   // groupSearchFilter
+                "",                   // groupMembershipFilter
+                "",                   // groupNameAttribute
+                "",                   // managerDN
+                "",                   // managerPassword
+                15,                   // updateInterval
+                false,                // disableLdapEmailResolver
+                "",                   // displayNameLdapAttribute
+                ""                    // emailAddressLdapAttribute
+        );
+    }
+}


### PR DESCRIPTION
Running the default SecurityReam filter last overrides the Authentication set by reverse-proxy-auth. In a default install, `AnonymousProcessingFilter` somehow resets the SecurityContext authentication, even though we should have set a token in our filter.

Running our filter last ensures our token is set regardless of prior filter actions.

Added tests to verify the fix.