### PR TITLE
Made retrievedUser a tranisent state

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -252,7 +252,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 	/**
 	 * The username retrieved from the header field, which is represented by the forwardedUser attribute.
 	 */
-	public String retrievedUser;
+	public transient String retrievedUser;
 
 	/**
 	 * Header name of the groups field.


### PR DESCRIPTION
Issue : Anytime a user edits a user does an operation on a Jenkins view it updates config.xml. The field `retrievedUser` also gets written into the config.xml which I believe was unintentional.

Change : Made the variable transient.

Ref: https://issues.jenkins-ci.org/browse/JENKINS-49274?workflowName=JNJira+%2B+In-Review&stepId=4