### PR TITLE
Call getHeaders() to load all plugins, rather than expecting a list of plugins with a delimiter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -44,6 +44,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
@@ -519,16 +520,15 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 						}
 
 					} else {
-						String groups = r.getHeader(headerGroups);
+						Enumeration<String> groups = r.getHeaders(headerGroups);
 
 						List<GrantedAuthority> localAuthorities = new ArrayList<GrantedAuthority>();
 						localAuthorities.add(AUTHENTICATED_AUTHORITY);
 
 						if (groups != null) {
-							StringTokenizer tokenizer = new StringTokenizer(groups, headerGroupsDelimiter);
-							while (tokenizer.hasMoreTokens()) {
-								final String token = tokenizer.nextToken().trim();
-								localAuthorities.add(new GrantedAuthorityImpl(token));
+							while (groups.hasMoreElements()) {
+								String group = groups.nextElement();
+								localAuthorities.add(new GrantedAuthorityImpl(group));
 							}
 						}
 


### PR DESCRIPTION
I'm not sure if this is something that the maintainers will want to merge, however we faced an issue when using this plugin with another third party application.

It seems that the plugin expects to receive a single string of plugins, with a pipe '|' as a delimiter. We're not quite sure why it was implemented this way, but it doesn't seem to be the standard way that groups would be passed in via the headers.

We've forked the plugin and made this change. Thought it worth highlighting via PR in case it was something you wanted to consider re-factoring / merging in.

The changes in this PR replace getHeader() with a call to getHeaders().

- [X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [X ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
