### PR TITLE
Add configurable LDAP timeout properties

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -87,6 +87,12 @@ THE SOFTWARE.
     <f:entry title="${%Cache Update Interval}" >
       <f:textbox name="updateInterval" value="${instance.updateInterval}" default="15"/>
     </f:entry>
+    <f:entry title="${%LDAP Connect Timeout}" >
+      <f:textbox name="ldapConnectTimeout" value="${instance.ldapConnectTimeout}" default="5000"/>
+    </f:entry>
+    <f:entry title="${%LDAP Read Timeout}" >
+      <f:textbox name="ldapReadTimeout" value="${instance.ldapReadTimeout}" default="60000"/>
+    </f:entry>
   </f:advanced>
   
   <j:set var="uras" value="${app.unprotectedRootActions}"/>

--- a/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
@@ -74,6 +74,8 @@ public class ReverseProxySecurityRealmTest {
                 "",                   // managerDN
                 "",                   // managerPassword
                 15,                   // updateInterval
+                5000,                 // ldapConnectTimeout
+                60000,                // ldapReadTimeout
                 false,                // disableLdapEmailResolver
                 "",                   // displayNameLdapAttribute
                 ""                    // emailAddressLdapAttribute


### PR DESCRIPTION
This PR adds 2 new fields to configure LDAP timeouts. Without it, no timeout was used, which could lead to LDAP connectivity issues causing deadlocks while accessing synchronised user cache provided by Guava.

###### Verification
- [x] new fields in UI:

![Screenshot 2022-09-12 at 15 40 30](https://user-images.githubusercontent.com/5772140/189669318-61a0f561-9ece-41a4-9c8d-4fa0202a3ccb.png)


- [x] timeouts used visible in logs:

```
Sep 12, 2022 1:27:21 PM FINE org.acegisecurity.ldap.DefaultInitialDirContextFactory connect
Creating InitialDirContext with environment {java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory, java.naming.referral=follow, java.naming.security.principal=***, com.sun.jndi.ldap.connect.timeout=30000, com.sun.jndi.ldap.connect.pool=true, com.sun.jndi.ldap.read.timeout=60000, java.naming.provider.url=ldaps://****:636/dc=***, java.naming.security.authentication=simple, java.naming.security.credentials=******}
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
