### PR TITLE
Save LDAP password as secret

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -408,7 +408,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
 	private String inferRootDN(String server) {
 		try {
 			Hashtable<String,String> props = new Hashtable<String,String>();
-			if(managerDN != null) {
+			if(managerDN != null && getManagerPassword() != null) {
 				props.put(Context.SECURITY_PRINCIPAL, managerDN);
 				props.put(Context.SECURITY_CREDENTIALS, getManagerPassword().getPlainText());
 			}

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -40,8 +40,7 @@ THE SOFTWARE.
       <f:textbox name="customLogOutUrl" value="${instance.customLogOutUrl}" />
     </f:entry>
 	<f:entry title="${%Server}" >
-	  <f:textbox name="server" value="${instance.server}"
-            checkUrl="'${rootURL}/securityRealms/LDAPSecurityRealm/serverCheck?field=server&amp;server='+encodeURIComponent(this.value)+'&amp;managerDN='+encodeURIComponent(this.form.elements['managerDN'].value)+'&amp;managerPassword='+encodeURIComponent(this.form.elements['managerPassword'].value)"/>
+	  <f:textbox name="server" value="${instance.server}"/>
 	</f:entry>
 	<f:entry title="${%root DN}" >
       <f:textbox name="rootDN" value="${instance.rootDN}" />
@@ -66,14 +65,10 @@ THE SOFTWARE.
       <f:textbox name="ldap.groupNameAttribute" value="${instance.groupNameAttribute}" />
     </f:entry>
     <f:entry title="${%Manager DN}" >
-      <f:textbox name="managerDN" value="${instance.managerDN}" autocomplete="off"
-         checkUrl="'${rootURL}/securityRealms/LDAPSecurityRealm/serverCheck?field=managerDN&amp;server='+encodeURIComponent(this.form.elements['ldap.server'].value)+'&amp;managerDN='+encodeURIComponent(this.value)+'&amp;managerPassword='+encodeURIComponent(this.form.elements['ldap.managerPassword'].value)"
-      />
+      <f:textbox name="managerDN" value="${instance.managerDN}" autocomplete="off"/>
     </f:entry>
-    <f:entry title="${%Manager Password}" >
-      <f:password name="managerPassword" value="${instance.managerPassword}" autocomplete="off"
-         checkUrl="'${rootURL}/securityRealms/LDAPSecurityRealm/serverCheck?field=password&amp;server='+encodeURIComponent(this.form.elements['ldap.server'].value)+'&amp;managerDN='+encodeURIComponent(this.form.elements['ldap.managerDN'].value)+'&amp;managerPassword='+encodeURIComponent(this.value)" 
-      />
+    <f:entry title="${%Manager Password}" field="managerPassword">
+      <f:password />
     </f:entry>
     <f:entry title="${%Display Name LDAP attribute}">
         <f:textbox name="displayNameLdapAttribute" value="${instance.displayNameLdapAttribute}" />

--- a/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm/config.jelly
@@ -67,8 +67,8 @@ THE SOFTWARE.
     <f:entry title="${%Manager DN}" >
       <f:textbox name="managerDN" value="${instance.managerDN}" autocomplete="off"/>
     </f:entry>
-    <f:entry title="${%Manager Password}" field="managerPassword">
-      <f:password />
+    <f:entry title="${%Manager Password}" >
+      <f:password name="managerPassword" value="${instance.managerPassword}" autocomplete="off" />
     </f:entry>
     <f:entry title="${%Display Name LDAP attribute}">
         <f:textbox name="displayNameLdapAttribute" value="${instance.displayNameLdapAttribute}" />

--- a/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.reverse_proxy_auth;
 
 import hudson.security.SecurityRealm;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
@@ -58,25 +59,25 @@ public class ReverseProxySecurityRealmTest {
     private ReverseProxySecurityRealm createBasicRealm() {
         return new ReverseProxySecurityRealm(
                 "X-Forwarded-User",   // forwardedUser
-                "X-Forwarded-Groups", // headerGroups
-                "|",                  // headerGroupsDelimiter
-                "",                   // customLogInUrl
-                "",                   // customLogOutUrl
-                "",                   // server
-                "",                   // rootDN
-                false,                // inhibitInferRootDN
-                "",                   // userSearchBase
-                "",                   // userSearch
-                "",                   // groupSearchBase
-                "",                   // groupSearchFilter
-                "",                   // groupMembershipFilter
-                "",                   // groupNameAttribute
-                "",                   // managerDN
-                "",                   // managerPassword
-                15,                   // updateInterval
-                false,                // disableLdapEmailResolver
-                "",                   // displayNameLdapAttribute
-                ""                    // emailAddressLdapAttribute
+                "X-Forwarded-Groups",       // headerGroups
+                "|",                        // headerGroupsDelimiter
+                "",                         // customLogInUrl
+                "",                         // customLogOutUrl
+                "",                         // server
+                "",                         // rootDN
+                false,                      // inhibitInferRootDN
+                "",                         // userSearchBase
+                "",                         // userSearch
+                "",                         // groupSearchBase
+                "",                         // groupSearchFilter
+                "",                         // groupMembershipFilter
+                "",                         // groupNameAttribute
+                "",                         // managerDN
+                Secret.fromString(""), // managerPassword
+                15,                         // updateInterval
+                false,                      // disableLdapEmailResolver
+                "",                         // displayNameLdapAttribute
+                ""                          // emailAddressLdapAttribute
         );
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
@@ -61,7 +61,7 @@ public class ReverseProxySecurityRealmTest {
 
     private ReverseProxySecurityRealm createBasicRealm() {
         return new ReverseProxySecurityRealm(
-                "X-Forwarded-User",   // forwardedUser
+                "X-Forwarded-User",         // forwardedUser
                 "X-Forwarded-Groups",       // headerGroups
                 "|",                        // headerGroupsDelimiter
                 "",                         // customLogInUrl
@@ -76,7 +76,7 @@ public class ReverseProxySecurityRealmTest {
                 "",                         // groupMembershipFilter
                 "",                         // groupNameAttribute
                 "",                         // managerDN
-                Secret.fromString(""), // managerPassword
+                Secret.fromString(""),      // managerPassword
                 15,                         // updateInterval
                 false,                      // disableLdapEmailResolver
                 "",                         // displayNameLdapAttribute

--- a/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.reverse_proxy_auth;
 
+import java.util.concurrent.Callable;
+
 import hudson.security.SecurityRealm;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;

--- a/src/test/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest/config.xml
@@ -1,0 +1,53 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson>
+    <disabledAdministrativeMonitors/>
+    <version>2.346.3</version>
+    <numExecutors>2</numExecutors>
+    <mode>NORMAL</mode>
+    <useSecurity>true</useSecurity>
+    <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+    <securityRealm class="org.jenkinsci.plugins.reverse_proxy_auth.ReverseProxySecurityRealm" plugin="reverse-proxy-auth-plugin@1.7.3">
+        <managerPassword>dGhlTWFuYWdlclBhc3N3MHJk</managerPassword>
+        <server>theServer</server>
+        <rootDN></rootDN>
+        <inhibitInferRootDN>false</inhibitInferRootDN>
+        <userSearchBase></userSearchBase>
+        <userSearch>uid={0}</userSearch>
+        <managerDN>theManagerDN</managerDN>
+        <updateInterval>15</updateInterval>
+        <forwardedUser>X-Forwarded-User</forwardedUser>
+        <headerGroups>X-Forwarded-Groups</headerGroups>
+        <headerGroupsDelimiter>|</headerGroupsDelimiter>
+        <disableLdapEmailResolver>false</disableLdapEmailResolver>
+        <displayNameLdapAttribute></displayNameLdapAttribute>
+        <emailAddressLdapAttribute></emailAddressLdapAttribute>
+    </securityRealm>
+    <disableRememberMe>false</disableRememberMe>
+    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}</workspaceDir>
+    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+    <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+    <jdks/>
+    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+    <clouds/>
+    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+    <views>
+        <hudson.model.AllView>
+            <owner class="hudson" reference="../../.."/>
+            <name>all</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+    </views>
+    <primaryView>all</primaryView>
+    <slaveAgentPort>0</slaveAgentPort>
+    <label></label>
+    <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+        <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+    </crumbIssuer>
+    <nodeProperties/>
+    <globalNodeProperties/>
+    <nodeRenameMigrationNeeded>false</nodeRenameMigrationNeeded>
+</hudson>

--- a/src/test/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealmTest/config.xml
@@ -9,7 +9,7 @@
     <securityRealm class="org.jenkinsci.plugins.reverse_proxy_auth.ReverseProxySecurityRealm" plugin="reverse-proxy-auth-plugin@1.7.3">
         <managerPassword>dGhlTWFuYWdlclBhc3N3MHJk</managerPassword>
         <server>theServer</server>
-        <rootDN></rootDN>
+        <rootDN>theRootDN</rootDN>
         <inhibitInferRootDN>false</inhibitInferRootDN>
         <userSearchBase></userSearchBase>
         <userSearch>uid={0}</userSearch>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR:

* saves the LDAP password as an encrypted secret instead of a simple base64 encoded string.
* removes the `checkUrl` attribute from the jelly config which seems to be a relic of old times and is returning 404
   * The 404 is mentioned in [JENKINS-156](https://issues.jenkins.io/browse/JENKINS-36156)
   * this points to [a google group question](https://groups.google.com/g/jenkinsci-users/c/HBHxN8SG2lw) mentioning that the plugin should not rely on internal URLs.
   * The current LDAP plugin has a doValidate endpoint with https://github.com/jenkinsci/ldap-plugin/blob/e5925c2efe39c4181b7ac77d2ebbb4f78ac7a856/src/main/java/hudson/security/LDAPSecurityRealm.java#L1531
which this plugin shouldn't, by rights, be using either.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
