### PR TITLE
Require Jenkins 2.479.1 or newer -- DRAFT - DO NOT MERGE

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.7</version>
+    <version>1.8</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,10 @@
-// Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jdkVersions: [11,17])
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.79</version>
+    <version>4.83</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>463.vedf8358e006b_</version>
+      <version>472.vf7c289a_4b_420</version>
     </dependency>
   </dependencies>
 
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <configuration>
           <configLocation>google_checks.xml</configLocation>
           <failOnViolation>true</failOnViolation>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.83</version>
+    <version>4.88</version>
     <relativePath />
   </parent>
 
@@ -43,15 +43,27 @@
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
   <properties>
-    <revision>1.7.8</revision>
+    <revision>1.8.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/reverse-proxy-auth-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.baseline>2.452</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3613.v584fca_12cf5c</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <!-- to appear earlier in the test CP for purposes of PCT -->
@@ -121,7 +133,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>472.vf7c289a_4b_420</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.2</version>
     <relativePath />
   </parent>
 
@@ -46,8 +46,8 @@
     <revision>1.8.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/reverse-proxy-auth-plugin</gitHubRepo>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -38,6 +38,13 @@ import hudson.tasks.Mailer.UserProperty;
 import hudson.util.FormValidation;
 import hudson.util.Scrambler;
 import hudson.util.Secret;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -61,13 +68,6 @@ import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import jenkins.model.Jenkins;
 import jenkins.security.ApiTokenProperty;
 import org.acegisecurity.Authentication;
@@ -103,7 +103,7 @@ import org.jenkinsci.plugins.reverse_proxy_auth.service.ProxyLDAPAuthoritiesPopu
 import org.jenkinsci.plugins.reverse_proxy_auth.service.ProxyLDAPUserDetailsService;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
 import org.springframework.dao.DataAccessException;
 
@@ -595,7 +595,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
             public void destroy() {}
         };
         Filter defaultFilter = super.createFilter(filterConfig);
-        return new ChainedServletFilter(defaultFilter, filter);
+        return new ChainedServletFilter2(defaultFilter, filter);
     }
 
     private ForwardedUserData retrieveForwardedData(HttpServletRequest r) {
@@ -619,9 +619,20 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
     }
 
     @Override
-    public String getPostLogOutUrl(StaplerRequest req, Authentication auth) {
+    public String getPostLogOutUrl2(StaplerRequest2 req, org.springframework.security.core.Authentication auth) {
         if (customLogOutUrl == null) {
-            return super.getPostLogOutUrl(req, auth);
+            return super.getPostLogOutUrl2(req, auth);
+        } else {
+            return customLogOutUrl;
+        }
+    }
+
+    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST", justification = "Temporary to allow testing by others")
+    public String getPostLogOutUrl2(StaplerRequest2 req, Authentication auth) {
+        if (customLogOutUrl == null) {
+            org.springframework.security.core.Authentication auth6 =
+                    (org.springframework.security.core.Authentication) auth;
+            return super.getPostLogOutUrl2(req, auth6);
         } else {
             return customLogOutUrl;
         }

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/ReverseProxySecurityRealm.java
@@ -225,6 +225,7 @@ public class ReverseProxySecurityRealm extends SecurityRealm {
      * CN e.g. <code>GroupDisplayName={0}</code> here you can configure that this (<code>
      * GroupDisplayName</code>) or another field should be used when looking for a users groups.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve the public API")
     public String groupNameAttribute;
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthenticator.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthenticator.java
@@ -41,7 +41,7 @@ public class DefaultReverseProxyAuthenticator
     }
 
     public void setMessageSource(@NonNull MessageSource messageSource) {
-        Assert.notNull("Message source must not be null");
+        Assert.notNull(messageSource, "Message source must not be null");
         messages = new MessageSourceAccessor(messageSource);
     }
 


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer -- DRAFT - DO NOT MERGE

Does not migrate from acegi security to Spring Security.  Hopes that an acegi Authorization object can be cast to a Spring Authorization object.  That seems highly unlikely, but the alternative is to migrate from acegi security to Spring Security and that is much more work.

Relies on the changes proposed in:

* #139 

### Testing done

Passes automated tests with Java 21.  Not tested in any interactive tests.  Likely will fail real use in many horrible ways.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
