### PR TITLE
Remove usages of Commons Logging

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthoritiesPopulator.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/DefaultReverseProxyAuthoritiesPopulator.java
@@ -21,8 +21,8 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Set;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jenkinsci.plugins.reverse_proxy_auth.ReverseProxySearchTemplate;
 import org.jenkinsci.plugins.reverse_proxy_auth.data.SearchTemplate;
 import org.jenkinsci.plugins.reverse_proxy_auth.data.UserSearchTemplate;
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
  */
 public class DefaultReverseProxyAuthoritiesPopulator implements ReverseProxyAuthoritiesPopulator {
 
-    private static final Log logger = LogFactory.getLog(DefaultReverseProxyAuthoritiesPopulator.class);
+    private static final Logger logger = Logger.getLogger(DefaultReverseProxyAuthoritiesPopulator.class.getName());
 
     /** A default role which will be assigned to all authenticated users if set */
     private GrantedAuthority defaultRole;
@@ -113,8 +113,8 @@ public class DefaultReverseProxyAuthoritiesPopulator implements ReverseProxyAuth
 
         Set<String> userRoles = reverseProxyTemplate.searchForSingleAttributeValues(searchTemplate, contextAuthorities);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Roles from search: " + userRoles);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("Roles from search: " + userRoles);
         }
 
         Iterator<String> it = userRoles.iterator();

--- a/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthenticationProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/reverse_proxy_auth/auth/ReverseProxyAuthenticationProvider.java
@@ -17,8 +17,8 @@ package org.jenkinsci.plugins.reverse_proxy_auth.auth;
 
 import java.util.Collection;
 import java.util.Collections;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jenkinsci.plugins.reverse_proxy_auth.model.ReverseProxyUserDetails;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
  * @author Wilder Rodrigues (wrodrigues@schubergphilis.com)
  */
 public class ReverseProxyAuthenticationProvider extends AbstractUserDetailsAuthenticationProvider {
-    private static final Log logger = LogFactory.getLog(ReverseProxyAuthenticationProvider.class);
+    private static final Logger logger = Logger.getLogger(ReverseProxyAuthenticationProvider.class.getName());
 
     private ReverseProxyAuthenticator authenticator;
     private ReverseProxyAuthoritiesPopulator authoritiesPopulator;
@@ -132,8 +132,8 @@ public class ReverseProxyAuthenticationProvider extends AbstractUserDetailsAuthe
             throw new BadCredentialsException("Empty Username");
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Retrieving user " + username);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("Retrieving user " + username);
         }
 
         String password = (String) authentication.getCredentials();


### PR DESCRIPTION
In the Jenkins ecosystem we generally prefer JUL to Commons Logging. This PR makes this plugin more consistent with the others.